### PR TITLE
Problem: complexity associated with error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,11 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -78,6 +83,7 @@ name = "bridge-cli"
 version = "0.1.0"
 dependencies = [
  "bridge 0.1.0",
+ "ctrlc 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -115,6 +121,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "crunchy"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ctrlc"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "difference"
@@ -457,6 +473,17 @@ dependencies = [
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nix"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -980,12 +1007,14 @@ dependencies = [
 "checksum backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ebbbf59b1c43eefa8c3ede390fcc36820b4999f7914104015be25025e0d62af2"
 "checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
 "checksum base64 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "229d032f1a99302697f10b27167ae6d03d49d032e6a8e2550e8d3fc13356d2b4"
+"checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "652805b7e73fada9d85e9a6682a4abd490cb52d96aeecc12e33a0de34dfd0d23"
 "checksum bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1b7db437d718977f6dc9b2e3fd6fc343c02ac6b899b73fdd2179163447bd9ce9"
 "checksum cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "deaf9ec656256bb25b404c51ef50097207b9cbb29c933d31f92cae5a8a0ffee0"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
+"checksum ctrlc 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "653abc99aa905f693d89df4797fadc08085baee379db92be9f2496cefe8a6f2c"
 "checksum difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3304d19798a8e067e48d8e69b2c37f0b5e9b4e462504ad9e27e9f3fce02bba8"
 "checksum docopt 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d8acd393692c503b168471874953a2531df0e9ab77d0b6bbc582395743300a4a"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
@@ -1022,6 +1051,7 @@ dependencies = [
 "checksum mio-uds 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1731a873077147b626d89cc6c2a0db6288d607496c5d10c0cfcf3adc697ec673"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "3a80f842784ef6c9a958b68b7516bc7e35883c614004dd94959a4dca1b716c09"
+"checksum nix 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a2c5afeb0198ec7be8569d666644b574345aad2e95a53baf3a532da3e0f3fb32"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 "checksum num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e7de20f146db9d920c45ee8ed8f71681fd9ade71909b48c3acbd766aa504cf10"

--- a/bridge/src/app.rs
+++ b/bridge/src/app.rs
@@ -7,6 +7,9 @@ use error::{Error, ResultExt, ErrorKind};
 use config::Config;
 use contracts::{home, foreign};
 
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+
 pub struct App<T> where T: Transport {
 	pub config: Config,
 	pub database_path: PathBuf,
@@ -14,6 +17,7 @@ pub struct App<T> where T: Transport {
 	pub home_bridge: home::HomeBridge,
 	pub foreign_bridge: foreign::ForeignBridge,
 	pub timer: Timer,
+	pub running: Arc<AtomicBool>
 }
 
 pub struct Connections<T> where T: Transport {
@@ -50,7 +54,7 @@ impl<T: Transport> Connections<T> {
 }
 
 impl App<Ipc> {
-	pub fn new_ipc<P: AsRef<Path>>(config: Config, database_path: P, handle: &Handle) -> Result<Self, Error> {
+	pub fn new_ipc<P: AsRef<Path>>(config: Config, database_path: P, handle: &Handle, running: Arc<AtomicBool>) -> Result<Self, Error> {
 		let connections = Connections::new_ipc(handle, &config.home.ipc, &config.foreign.ipc)?;
 		let result = App {
 			config,
@@ -59,6 +63,7 @@ impl App<Ipc> {
 			home_bridge: home::HomeBridge::default(),
 			foreign_bridge: foreign::ForeignBridge::default(),
 			timer: Timer::default(),
+			running,
 		};
 		Ok(result)
 	}
@@ -73,6 +78,7 @@ impl<T: Transport> App<T> {
 			home_bridge: home::HomeBridge::default(),
 			foreign_bridge: foreign::ForeignBridge::default(),
 			timer: self.timer.clone(),
+			running: self.running.clone(),
 		}
 	}
 }

--- a/bridge/src/error.rs
+++ b/bridge/src/error.rs
@@ -19,6 +19,7 @@ error_chain! {
 	}
 
 	errors {
+	    ShutdownRequested
 		// api timeout
 		Timeout(request: &'static str) {
 			description("Request timeout"),

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,3 +16,4 @@ docopt = "0.8.1"
 log = "0.3"
 env_logger = "0.4"
 futures = "0.1.14"
+ctrlc = { version = "3.1", features = ["termination"] }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -9,7 +9,7 @@ extern crate log;
 extern crate env_logger;
 extern crate bridge;
 
-use std::{env, fs};
+use std::{env, fs, io};
 use std::sync::Arc;
 use std::path::PathBuf;
 use docopt::Docopt;
@@ -21,6 +21,41 @@ use bridge::bridge::{create_bridge, create_deploy, Deployed};
 use bridge::config::Config;
 use bridge::error::{Error, ErrorKind};
 use bridge::web3;
+
+const ERR_UNKNOWN: i32 = 1;
+const ERR_IO_ERROR: i32 = 2;
+const ERR_CANNOT_CONNECT: i32 = 10;
+const ERR_CONNECTION_LOST: i32 = 11;
+const ERR_BRIDGE_CRASH: i32 = 11;
+
+pub struct UserFacingError(i32, Error);
+
+impl From<Error> for UserFacingError {
+	fn from(err: Error) -> Self {
+		UserFacingError(ERR_UNKNOWN, err)
+	}
+}
+
+impl From<String> for UserFacingError {
+	fn from(err: String) -> Self {
+		UserFacingError(ERR_UNKNOWN, err.into())
+	}
+}
+
+
+impl From<io::Error> for UserFacingError {
+	fn from(err: io::Error) -> Self {
+		UserFacingError(ERR_IO_ERROR, err.into())
+	}
+}
+
+
+impl From<(i32, Error)> for UserFacingError {
+	fn from((code, err): (i32, Error)) -> Self {
+		UserFacingError(code, err)
+	}
+}
+
 
 const USAGE: &'static str = r#"
 Ethereum-Kovan bridge.
@@ -46,16 +81,20 @@ fn main() {
 
 	match result {
 		Ok(s) => println!("{}", s),
-		Err(err) => print_err(err),
+		Err(UserFacingError(code, err)) => {
+			print_err(err);
+			::std::process::exit(code);
+		},
 	}
 }
+
 
 fn print_err(err: Error) {
 	let message = err.iter().map(|e| e.to_string()).collect::<Vec<_>>().join("\n\nCaused by:\n  ");
 	println!("{}", message);
 }
 
-fn execute<S, I>(command: I) -> Result<String, Error> where I: IntoIterator<Item=S>, S: AsRef<str> {
+fn execute<S, I>(command: I) -> Result<String, UserFacingError> where I: IntoIterator<Item=S>, S: AsRef<str> {
 	info!(target: "bridge", "Parsing cli arguments");
 	let args: Args = Docopt::new(USAGE)
 		.and_then(|d| d.argv(command).deserialize()).map_err(|e| e.to_string())?;
@@ -67,14 +106,12 @@ fn execute<S, I>(command: I) -> Result<String, Error> where I: IntoIterator<Item
 	let mut event_loop = Core::new().unwrap();
 
 	info!(target: "bridge", "Establishing ipc connection");
-	let app = loop {
-		match App::new_ipc(config.clone(), &args.arg_database, &event_loop.handle()) {
-			Ok(app) => break app,
+	let app = match App::new_ipc(config.clone(), &args.arg_database, &event_loop.handle()) {
+			Ok(app) => app,
 			Err(e) => {
-				warn!("Can't establish an IPC connection, will attempt to reconnect: {:?}", e);
-				::std::thread::sleep(::std::time::Duration::from_secs(1));
+				warn!("Can't establish an IPC connection: {:?}", e);
+				return Err((ERR_CANNOT_CONNECT, e).into());
 			},
-		}
 	};
 	let app_ref = Arc::new(app.as_ref());
 
@@ -96,32 +133,22 @@ fn execute<S, I>(command: I) -> Result<String, Error> where I: IntoIterator<Item
 
 	info!(target: "bridge", "Starting listening to events");
 	let bridge = create_bridge(app_ref.clone(), &database).and_then(|_| future::ok(true)).collect();
-	let mut result = event_loop.run(bridge);
-	loop {
-		result = match &result {
-			&Err(Error(ErrorKind::Web3(web3::error::Error(web3::error::ErrorKind::Io(ref e), _)), _)) if e.kind() == ::std::io::ErrorKind::BrokenPipe => {
-			    warn!("Connection to a node has been severed, attempting to reconnect");
-				let app = match App::new_ipc(config.clone(), &args.arg_database, &event_loop.handle()) {
-					Ok(app) => {
-						warn!("Connection has been re-established, restarting");
-						app
-					},
-					_ => {
-						::std::thread::sleep(::std::time::Duration::from_secs(1));
-						continue
-					},
-				};
-				let app_ref = Arc::new(app.as_ref());
-				let bridge = create_bridge(app_ref.clone(), &database).and_then(|_| future::ok(true)).collect();
-				event_loop.run(bridge)
+	let result = event_loop.run(bridge);
+	match result {
+			Err(Error(ErrorKind::Web3(web3::error::Error(web3::error::ErrorKind::Io(e), _)), _)) => {
+				if e.kind() == ::std::io::ErrorKind::BrokenPipe {
+					warn!("Connection to a node has been severed");
+					return Err((ERR_CONNECTION_LOST, e.into()).into());
+				} else {
+					warn!("I/O error: {:?}", e);
+					return Err((ERR_IO_ERROR, e.into()).into());
+				}
 			},
-			&Err(ref e) => {
-				warn!("Bridge is down with {}, attempting to restart", e);
-				let bridge = create_bridge(app_ref.clone(), &database).and_then(|_| future::ok(true)).collect();
-				event_loop.run(bridge)
+			Err(e) => {
+				warn!("Bridge crashed with {}", e);
+				return Err((ERR_BRIDGE_CRASH, e).into());
 			},
-			&Ok(_) => break,
-		};
+			Ok(_) => (),
 	}
 
 	Ok("Done".into())

--- a/examples/supervisor
+++ b/examples/supervisor
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+while true; do
+        "$@"
+        if [ $? == 3 ]; then
+                # shutdown requested by user
+                echo "Shutting down"
+                exit 0
+        fi
+        echo "Restarting after 1 second"
+        sleep 1
+done


### PR DESCRIPTION
Currently, bridge will try to handle errors in some
way in order to attempt to restore its functionality.

However, this limits as to how the errors can be handled
as every time a change in handling is needed, a patch
for bridge will needed.

Overtime, this will inevitably grow into a full-fledged
supervisor.

However, there are already supervisor programs out there
(starting from all-encompassing systemd down to small
supervision utilities)

Solution: revert the handling of errors to the old behaviour
but (very importantly) make bridge return meaningful error
codes for all known error types so that the supervisor
can make a proper decision as to what has to be done
(restart, delayed restart, permanent shutdown, notification,
etc.)