### PR TITLE
Problem: bridge crashes with insufficient balance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,7 @@ dependencies = [
  "docopt 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/bridge/src/bridge/balance.rs
+++ b/bridge/src/bridge/balance.rs
@@ -1,0 +1,62 @@
+use futures::{Future, Stream, Poll};
+use tokio_timer::{Timer, Timeout};
+use web3::Transport;
+use web3::types::U256;
+use api::{self, ApiCall};
+use error::Error;
+use config::Node;
+
+/// State of balance checking.
+enum BalanceCheckState<T: Transport> {
+	/// Deposit relay is waiting for logs.
+	Wait,
+	/// Balance request is in progress.
+	BalanceRequest {
+		future: Timeout<ApiCall<U256, T::Out>>,
+	},
+	/// Balance request completed.
+	Yield(Option<U256>),
+}
+
+pub struct BalanceCheck<T: Transport> {
+	transport: T,
+	state: BalanceCheckState<T>,
+	timer: Timer,
+	node: Node,
+}
+
+pub fn create_balance_check<T: Transport + Clone>(transport: T, node: Node) -> BalanceCheck<T> {
+	BalanceCheck {
+		state: BalanceCheckState::Wait,
+		timer: Timer::default(),
+		transport,
+		node,
+	}
+}
+
+impl<T: Transport> Stream for BalanceCheck<T> {
+	type Item = U256;
+	type Error = Error;
+
+	fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+		loop {
+			let next_state = match self.state {
+				BalanceCheckState::Wait => {
+					BalanceCheckState::BalanceRequest {
+						future: self.timer.timeout(api::balance(&self.transport, self.node.account, None),
+						                           self.node.request_timeout),
+					}
+				},
+				BalanceCheckState::BalanceRequest { ref mut future } => {
+					let value = try_ready!(future.poll());
+					BalanceCheckState::Yield(Some(value))
+				},
+				BalanceCheckState::Yield(ref mut balance) => match balance.take() {
+					None => BalanceCheckState::Wait,
+					some => return Ok(some.into()),
+				}
+			};
+			self.state = next_state;
+		}
+	}
+}

--- a/bridge/src/bridge/withdraw_relay.rs
+++ b/bridge/src/bridge/withdraw_relay.rs
@@ -1,16 +1,16 @@
-use std::sync::Arc;
-use futures::{Future, Stream, Poll};
+use std::sync::{Arc, RwLock};
+use futures::{self, Future, Stream, Poll};
 use futures::future::{JoinAll, join_all, Join};
 use tokio_timer::Timeout;
 use web3::Transport;
-use web3::types::{H256, Address, FilterBuilder, Log, Bytes, TransactionRequest};
+use web3::types::{H256, U256, Address, FilterBuilder, Log, Bytes, TransactionRequest};
 use ethabi::{RawLog, self};
 use app::App;
 use api::{self, LogStream, ApiCall};
 use contracts::foreign;
 use util::web3_filter;
 use database::Database;
-use error::{self, Error};
+use error::{self, Error, ErrorKind};
 use message_to_mainnet::MessageToMainnet;
 use signature::Signature;
 
@@ -73,7 +73,7 @@ pub enum WithdrawRelayState<T: Transport> {
 	Yield(Option<u64>),
 }
 
-pub fn create_withdraw_relay<T: Transport + Clone>(app: Arc<App<T>>, init: &Database) -> WithdrawRelay<T> {
+pub fn create_withdraw_relay<T: Transport + Clone>(app: Arc<App<T>>, init: &Database, home_balance: Arc<RwLock<Option<U256>>>) -> WithdrawRelay<T> {
 	let logs_init = api::LogStreamInit {
 		after: init.checked_withdraw_relay,
 		request_timeout: app.config.foreign.request_timeout,
@@ -88,6 +88,7 @@ pub fn create_withdraw_relay<T: Transport + Clone>(app: Arc<App<T>>, init: &Data
 		foreign_contract: init.foreign_contract_address,
 		state: WithdrawRelayState::Wait,
 		app,
+		home_balance,
 	}
 }
 
@@ -97,6 +98,7 @@ pub struct WithdrawRelay<T: Transport> {
 	state: WithdrawRelayState<T>,
 	foreign_contract: Address,
 	home_contract: Address,
+	home_balance: Arc<RwLock<Option<U256>>>,
 }
 
 impl<T: Transport> Stream for WithdrawRelay<T> {
@@ -154,9 +156,20 @@ impl<T: Transport> Stream for WithdrawRelay<T> {
 					}
 				},
 				WithdrawRelayState::FetchMessagesSignatures { ref mut future, block } => {
+					let home_balance = self.home_balance.read().unwrap();
+					if home_balance.is_none() {
+						warn!("home contract balance is unknown");
+						return Ok(futures::Async::NotReady);
+					}
+
 					let (messages_raw, signatures_raw) = try_ready!(future.poll());
 					info!("fetching messages and signatures complete");
 					assert_eq!(messages_raw.len(), signatures_raw.len());
+
+					let balance_required = U256::from(self.app.config.txs.withdraw_relay.gas) * U256::from(self.app.config.txs.withdraw_relay.gas_price) * U256::from(messages_raw.len());
+					if balance_required > *home_balance.as_ref().unwrap() {
+						return Err(ErrorKind::InsufficientFunds.into())
+					}
 
 					let app = &self.app;
 					let home_contract = &self.home_contract;

--- a/bridge/src/error.rs
+++ b/bridge/src/error.rs
@@ -20,6 +20,7 @@ error_chain! {
 
 	errors {
 	    ShutdownRequested
+		InsufficientFunds
 		// api timeout
 		Timeout(request: &'static str) {
 			description("Request timeout"),

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,4 +16,5 @@ docopt = "0.8.1"
 log = "0.3"
 env_logger = "0.4"
 futures = "0.1.14"
+jsonrpc-core = "8.0"
 ctrlc = { version = "3.1", features = ["termination"] }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -9,6 +9,7 @@ extern crate log;
 extern crate env_logger;
 extern crate bridge;
 extern crate ctrlc;
+extern crate jsonrpc_core as rpc;
 
 use std::{env, fs, io};
 use std::sync::Arc;
@@ -26,6 +27,8 @@ use bridge::web3;
 const ERR_UNKNOWN: i32 = 1;
 const ERR_IO_ERROR: i32 = 2;
 const ERR_SHUTDOWN_REQUESTED: i32 = 3;
+const ERR_INSUFFICIENT_FUNDS: i32 = 4;
+const ERR_RPC_ERROR: i32 = 5;
 const ERR_CANNOT_CONNECT: i32 = 10;
 const ERR_CONNECTION_LOST: i32 = 11;
 const ERR_BRIDGE_CRASH: i32 = 11;
@@ -159,7 +162,20 @@ fn execute<S, I>(command: I, running: Arc<AtomicBool>) -> Result<String, UserFac
 		    Err(e @ Error(ErrorKind::ShutdownRequested, _)) => {
 				info!("Shutdown requested, terminating");
 				return Err((ERR_SHUTDOWN_REQUESTED, e.into()).into());
-			}
+			},
+  		    Err(e @ Error(ErrorKind::InsufficientFunds, _)) => {
+  			    info!("Insufficient funds, terminating");
+			    return Err((ERR_INSUFFICIENT_FUNDS, e.into()).into());
+		    },
+     	    Err(Error(ErrorKind::Web3(web3::error::Error(web3::error::ErrorKind::Rpc(e), _)), _)) => {
+				if e.code == rpc::ErrorCode::ServerError(-32010) {
+					info!("Insufficient funds, terminating");
+					return Err((ERR_INSUFFICIENT_FUNDS, ErrorKind::Web3(web3::error::ErrorKind::Rpc(e).into()).into()).into());
+				} else {
+					info!("RPC error {:?}", e);
+					return Err((ERR_RPC_ERROR, ErrorKind::Web3(web3::error::ErrorKind::Rpc(e).into()).into()).into());
+				}
+			},
 			Err(e) => {
 				warn!("Bridge crashed with {}", e);
 				return Err((ERR_BRIDGE_CRASH, e).into());

--- a/integration-tests/bridge_config_gas_price.toml
+++ b/integration-tests/bridge_config_gas_price.toml
@@ -1,0 +1,30 @@
+estimated_gas_cost_of_withdraw = 0
+
+[home]
+account = "0x00bd138abd70e2f00903268f3db08f2d25677c9e"
+ipc = "./home.ipc"
+required_confirmations = 0
+
+[home.contract]
+bin = "../compiled_contracts/HomeBridge.bin"
+
+[foreign]
+account = "0x00bd138abd70e2f00903268f3db08f2d25677c9e"
+ipc = "./foreign.ipc"
+required_confirmations = 0
+
+[foreign.contract]
+bin = "../compiled_contracts/ForeignBridge.bin"
+
+[authorities]
+accounts = [
+	"0x00bd138abd70e2f00903268f3db08f2d25677c9e",
+]
+required_signatures = 1
+
+[transactions]
+home_deploy = { gas = 3000000, gas_price = 1 }
+foreign_deploy = { gas = 3000000, gas_price = 1 }
+deposit_relay = { gas = 3000000, gas_price = 1 }
+withdraw_relay = { gas = 3000000, gas_price = 1 }
+withdraw_confirm = { gas = 3000000, gas_price = 1 }

--- a/integration-tests/tests/insufficient_funds.rs
+++ b/integration-tests/tests/insufficient_funds.rs
@@ -1,0 +1,401 @@
+/// spins up two parity nodes with the dev chain.
+/// starts one bridge authority that connects the two.
+/// does a deposit by sending ether to the HomeBridge.
+/// asserts that the deposit got relayed to foreign chain.
+/// does a withdraw by executing ForeignBridge.transferToHomeBridge.
+/// asserts that the withdraw got relayed to home chain.
+
+extern crate tempdir;
+extern crate ethereum_types;
+extern crate web3;
+extern crate tokio_core;
+extern crate bridge;
+extern crate ethabi;
+extern crate serde_json;
+#[macro_use] extern crate ethabi_contract;
+#[macro_use] extern crate ethabi_derive;
+
+use_contract!(token, "Token", "../compiled_contracts/Token.abi");
+
+use std::process::Command;
+use std::time::Duration;
+use std::thread;
+use std::path::Path;
+
+use tokio_core::reactor::Core;
+
+use web3::transports::ipc::Ipc;
+use web3::api::Namespace;
+use ethereum_types::{Address, U256};
+
+extern crate rustc_hex;
+use rustc_hex::FromHex;
+
+const TMP_PATH: &str = "tmp";
+
+fn parity_home_command() -> Command {
+	let mut command = Command::new("parity");
+	command
+		.arg("--base-path").arg(format!("{}/home", TMP_PATH))
+		.arg("--chain").arg("dev")
+		.arg("--ipc-path").arg("home.ipc")
+		.arg("--logging").arg("rpc=trace")
+		.arg("--jsonrpc-port").arg("8550")
+		.arg("--jsonrpc-apis").arg("all")
+		.arg("--port").arg("30310")
+		.arg("--gasprice").arg("1")
+		.arg("--reseal-min-period").arg("0")
+		.arg("--no-ws")
+		.arg("--no-dapps")
+		.arg("--no-ui");
+	command
+}
+
+fn parity_foreign_command() -> Command {
+	let mut command = Command::new("parity");
+	command
+		.arg("--base-path").arg(format!("{}/foreign", TMP_PATH))
+		.arg("--chain").arg("dev")
+		.arg("--ipc-path").arg("foreign.ipc")
+		.arg("--logging").arg("rpc=trace")
+		.arg("--jsonrpc-port").arg("8551")
+		.arg("--jsonrpc-apis").arg("all")
+		.arg("--port").arg("30311")
+		.arg("--gasprice").arg("1")
+		.arg("--reseal-min-period").arg("0")
+		.arg("--no-ws")
+		.arg("--no-dapps")
+		.arg("--no-ui");
+	command
+}
+
+fn address_from_str(string: &'static str) -> web3::types::Address {
+	web3::types::Address::from(&Address::from(string).0[..])
+}
+
+#[test]
+fn test_insufficient_funds() {
+	if Path::new(TMP_PATH).exists() {
+		std::fs::remove_dir_all(TMP_PATH).expect("failed to remove tmp dir");
+	}
+	let _tmp_dir = tempdir::TempDir::new(TMP_PATH).expect("failed to create tmp dir");
+
+	println!("\nbuild the bridge cli executable so we can run it later\n");
+	assert!(Command::new("cargo")
+		.env("RUST_BACKTRACE", "1")
+		.current_dir("../cli")
+		.arg("build")
+		.status()
+		.expect("failed to build bridge cli")
+		.success());
+
+	// start a parity node that represents the home chain
+	let mut parity_home = parity_home_command()
+		.spawn()
+		.expect("failed to spawn parity home node");
+
+	// start a parity node that represents the foreign chain
+	let mut parity_foreign = parity_foreign_command()
+		.spawn()
+		.expect("failed to spawn parity foreign node");
+
+	// give the clients time to start up
+	thread::sleep(Duration::from_millis(3000));
+
+	// A address containing a lot of tokens (0x00a329c0648769a73afac7f9381e08fb43dbea72) should be
+	// automatically added with a password being an empty string.
+	// source: https://paritytech.github.io/wiki/Private-development-chain.html
+	let user_address = "0x00a329c0648769a73afac7f9381e08fb43dbea72";
+
+	let authority_address = "0x00bd138abd70e2f00903268f3db08f2d25677c9e";
+
+	// create authority account on home
+	let exit_status = Command::new("curl")
+		.arg("--data").arg(r#"{"jsonrpc":"2.0","method":"parity_newAccountFromPhrase","params":["node0", ""],"id":0}"#)
+		.arg("-H").arg("Content-Type: application/json")
+		.arg("-X").arg("POST")
+		.arg("localhost:8550")
+		.status()
+		.expect("failed to create authority account on home");
+	assert!(exit_status.success());
+	// TODO [snd] assert that created address matches authority_address
+
+	// create authority account on foreign
+	let exit_status = Command::new("curl")
+		.arg("--data").arg(r#"{"jsonrpc":"2.0","method":"parity_newAccountFromPhrase","params":["node0", ""],"id":0}"#)
+		.arg("-H").arg("Content-Type: application/json")
+		.arg("-X").arg("POST")
+		.arg("localhost:8551")
+		.status()
+		.expect("failed to create/unlock authority account on foreign");
+	assert!(exit_status.success());
+
+	// TODO [snd] assert that created address matches authority_address
+	// give the operations time to complete
+	thread::sleep(Duration::from_millis(5000));
+
+	// kill the clients so we can restart them with the accounts unlocked
+	parity_home.kill().unwrap();
+	parity_foreign.kill().unwrap();
+
+	// wait for clients to shut down
+	thread::sleep(Duration::from_millis(5000));
+
+	// start a parity node that represents the home chain with accounts unlocked
+	let mut parity_home = parity_home_command()
+		.arg("--unlock").arg(format!("{},{}", user_address, authority_address))
+		.arg("--password").arg("password.txt")
+		.spawn()
+		.expect("failed to spawn parity home node");
+
+	// start a parity node that represents the foreign chain with accounts unlocked
+	let mut parity_foreign = parity_foreign_command()
+		.arg("--unlock").arg(format!("{},{}", user_address, authority_address))
+		.arg("--password").arg("password.txt")
+		.spawn()
+		.expect("failed to spawn parity foreign node");
+
+	// give nodes time to start up
+	thread::sleep(Duration::from_millis(10000));
+
+
+	println!("\nfund foreign authority address\n");
+	let exit_status = Command::new("curl")
+		.arg("--data").arg(format!(r#"{{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{{
+			"from": "{}",
+			"to": "{}",
+			"value": "{}"
+		}}],"id":0}}"#, user_address, authority_address, "0xffffffff"))
+		.arg("-H").arg("Content-Type: application/json")
+		.arg("-X").arg("POST")
+		.arg("localhost:8550")
+		.status()
+		.expect("failed to deposit into HomeBridge");
+	assert!(exit_status.success());
+
+	println!("\nfund foreign authority address (foreign)\n");
+	let exit_status = Command::new("curl")
+		.arg("--data").arg(format!(r#"{{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{{
+			"from": "{}",
+			"to": "{}",
+			"value": "{}"
+		}}],"id":0}}"#, user_address, authority_address, "0xffffffff"))
+		.arg("-H").arg("Content-Type: application/json")
+		.arg("-X").arg("POST")
+		.arg("localhost:8551")
+		.status()
+		.expect("failed to deposit into HomeBridge");
+	assert!(exit_status.success());
+
+
+	// start bridge authority 1
+	let mut bridge1 = Command::new("env")
+		.arg("RUST_BACKTRACE=1")
+		.arg("../target/debug/bridge")
+		.env("RUST_LOG", "info")
+		.arg("--config").arg("bridge_config_gas_price.toml")
+		.arg("--database").arg("tmp/bridge1_db.txt")
+		.spawn()
+		.expect("failed to spawn bridge process");
+
+	// give the bridge time to start up and deploy the contracts
+	thread::sleep(Duration::from_millis(10000));
+
+	let home_contract_address = "0xebd3944af37ccc6b67ff61239ac4fef229c8f69f";
+	let foreign_contract_address = "0xebd3944af37ccc6b67ff61239ac4fef229c8f69f";
+
+	// connect to foreign and home via IPC
+	let mut event_loop = Core::new().unwrap();
+	let foreign_transport = Ipc::with_event_loop("foreign.ipc", &event_loop.handle())
+		.expect("failed to connect to foreign.ipc");
+	let foreign = bridge::contracts::foreign::ForeignBridge::default();
+	let foreign_eth = web3::api::Eth::new(foreign_transport);
+	let home_transport = Ipc::with_event_loop("home.ipc", &event_loop.handle())
+		.expect("failed to connect to home.ipc");
+	let home_eth = web3::api::Eth::new(home_transport);
+
+	// deploy the token
+	println!("== deploy the token");
+	let token_constructor = token::Token::default().constructor(include_str!("../../compiled_contracts/Token.bin").from_hex().unwrap());
+	let future = foreign_eth.send_transaction(web3::types::TransactionRequest {
+		from: address_from_str(authority_address),
+		to: None,
+		gas: None,
+		gas_price: None,
+		value: None,
+		data: Some(token_constructor.into()),
+		condition: None,
+		nonce: None,
+	});
+	let tx = event_loop.run(future).unwrap();
+	let future = foreign_eth.transaction_receipt(tx);
+	let token_receipt = event_loop.run(future).unwrap();
+	let token_addr = token_receipt.unwrap().contract_address.unwrap();
+
+	// check token validity
+    let is_token = token::Token::default().functions().is_token().input();
+	let future = foreign_eth.call(web3::types::CallRequest {
+		from: None,
+		to: token_addr,
+		gas: None,
+		gas_price: None,
+		value: None,
+		data: Some(web3::types::Bytes(is_token)),
+	}, None);
+
+	event_loop.run(future).unwrap();
+
+	// set the token
+	println!("== set the token");
+	let set_token = foreign.functions().set_token_address().input(token_addr);
+	let future = foreign_eth.send_transaction(web3::types::TransactionRequest {
+		from: address_from_str(authority_address),
+		to: Some(address_from_str(foreign_contract_address)),
+		gas: None,
+		gas_price: None,
+		value: None,
+		data: Some(web3::types::Bytes(set_token)),
+		condition: None,
+		nonce: None,
+	});
+	event_loop.run(future).unwrap();
+
+	// check that the token has been set correctly
+	println!("== check token setup");
+	let token = foreign.functions().erc20token().input();
+	let future = foreign_eth.call(web3::types::CallRequest {
+		from: None,
+		to: address_from_str(foreign_contract_address),
+		gas: None,
+		gas_price: None,
+		value: None,
+		data: Some(web3::types::Bytes(token)),
+	}, None);
+
+	let response = event_loop.run(future).unwrap();
+	assert_eq!(Address::from(&response.0.as_slice()[(response.0.len()-20)..]), token_addr);
+	let erc20 = bridge::contracts::erc20::ERC20::default();
+
+	// fund the contract
+	println!("== set mint agent");
+	let set_mint_agent = token::Token::default().functions().set_mint_agent().input(address_from_str(authority_address), true);
+	let future = foreign_eth.send_transaction(web3::types::TransactionRequest {
+		from: address_from_str(authority_address),
+		to: Some(token_addr),
+		gas: None,
+		gas_price: None,
+		value: None,
+		data: Some(web3::types::Bytes(set_mint_agent)),
+		condition: None,
+		nonce: None,
+	});
+	event_loop.run(future).unwrap();
+
+	println!("== fund contract through minting");
+	let fund = token::Token::default().functions().mint().input(address_from_str(foreign_contract_address), ::std::u32::MAX);
+	let future = foreign_eth.send_transaction(web3::types::TransactionRequest {
+		from: address_from_str(authority_address),
+		to: Some(token_addr),
+		gas: None,
+		gas_price: None,
+		value: None,
+		data: Some(web3::types::Bytes(fund)),
+		condition: None,
+		nonce: None,
+	});
+	event_loop.run(future).unwrap();
+
+	println!("== check token supply");
+	let supply_payload = token::Token::default().functions().total_supply().input();
+	let supply_call = web3::types::CallRequest {
+			from: None,
+			to: token_addr,
+			gas: None,
+			gas_price: None,
+			value: None,
+			data: Some(web3::types::Bytes(supply_payload)),
+	};
+	assert!(!U256::from(event_loop.run(foreign_eth.call(supply_call, None)).unwrap().0.as_slice()).is_zero());
+
+
+	println!("== check contract balance");
+	let balance_payload = erc20.functions().balance_of().input(address_from_str(foreign_contract_address));
+	let balance_call = web3::types::CallRequest {
+			from: None,
+			to: token_addr,
+			gas: None,
+			gas_price: None,
+			value: None,
+			data: Some(web3::types::Bytes(balance_payload)),
+	};
+	assert!(!U256::from(event_loop.run(foreign_eth.call(balance_call, None)).unwrap().0.as_slice()).is_zero());
+
+	// TODO: remove the balance from the foreign bridge
+	println!("\nchecking foreign balance");
+	let balance_check = Command::new("curl")
+		.arg("--data").arg(format!(r#"{{"id": "balance", "jsonrpc":"2.0","method":"eth_getBalance","params":["{}"]}}"#, authority_address))
+		.arg("-H").arg("Content-Type: application/json")
+		.arg("-X").arg("POST")
+		.arg("localhost:8551")
+		.output()
+		.expect("failed to get balance");
+	let response: serde_json::Value = serde_json::from_reader(&balance_check.stdout[..]).unwrap();
+	let balance = &response["result"];
+
+	println!("\nbalance: {}", balance);
+
+	println!("\nremoving funding from the foreign authority address\n");
+	let exit_status = Command::new("curl")
+		.arg("--data").arg(format!(r#"{{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{{
+			"from": "{}",
+			"to": "{}",
+			"value": {},
+            "gasPrice": "0x0"
+		}}],"id":0}}"#, authority_address, "0x0000000000000000000000000000000000000000", balance))
+		.arg("-H").arg("Content-Type: application/json")
+		.arg("-X").arg("POST")
+		.arg("localhost:8551")
+		.status()
+		.expect("failed to deposit into HomeBridge");
+	assert!(exit_status.success());
+
+	thread::sleep(Duration::from_millis(3000));
+
+	println!("\nchecking foreign balance again");
+	let balance_check = Command::new("curl")
+		.arg("--data").arg(format!(r#"{{"id": "balance", "jsonrpc":"2.0","method":"eth_getBalance","params":["{}"]}}"#, authority_address))
+		.arg("-H").arg("Content-Type: application/json")
+		.arg("-X").arg("POST")
+		.arg("localhost:8551")
+		.output()
+		.expect("failed to get balance");
+	let response: serde_json::Value = serde_json::from_reader(&balance_check.stdout[..]).unwrap();
+	let balance = &response["result"];
+
+	println!("\nbalance: {}", balance);
+
+	assert_eq!(balance, &serde_json::Value::String("0x0".into()));
+
+
+	println!("\nuser deposits ether into HomeBridge\n");
+	// TODO [snd] use rpc client here instead of curl
+	let exit_status = Command::new("curl")
+		.arg("--data").arg(format!(r#"{{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{{
+			"from": "{}",
+			"to": "{}",
+			"value": "0x186a0"
+		}}],"id":0}}"#, user_address, home_contract_address))
+		.arg("-H").arg("Content-Type: application/json")
+		.arg("-X").arg("POST")
+		.arg("localhost:8550")
+		.status()
+		.expect("failed to deposit into HomeBridge");
+	assert!(exit_status.success());
+
+	// TODO: bridge should exit
+	let status = bridge1.wait().unwrap();
+	assert_eq!(status.code().unwrap(), 4); // 4 stands for INSUFFICENT_FUNDS
+
+	parity_home.kill().unwrap();
+	parity_foreign.kill().unwrap();
+}


### PR DESCRIPTION
Currently there are two possible situations related to low balance on
the account which is used for bridge operations:

1. The account which is used to sign transactions to be addressed by
ForeignBridge contract has low balance. So, the bridge is not able to do
deposit_relay and withdraw_confirm.
2. The account which is used to sign transactions to be addressed by
HomeBridge contract has low balance. So, the bridge is not able to do
withdraw_relay.

In both cases bridges hangs silently at the moment of sending
transactions and does not proceed with further actions even the
operation is intended to be performed in opposite direction (e.g. the
bridge hangs at the moment to perform withdraw_relay, so deposit_relay
cannot be performed either).

Solution: make bridge track its balance and hande insufficient

Bridge will crash with ERR_INSUFFICIENT_FUNDS (code 4) so that
supervisor can decide what should happen next. It will also log the
condition.

P.S.Make sure to run the tests with `--test-threads=1` to avoid
other test conflicting with this one. A better solution to this
issue must be devised later, however.