### PR TITLE
Problem: non-integration tests don't compile

### DIFF
--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -93,6 +93,7 @@ macro_rules! test_app_stream {
 		#[allow(unused_imports)]
 		fn $name() {
 			use self::std::sync::Arc;
+			use self::std::sync::atomic::AtomicBool;
 			use self::std::time::Duration;
 			use self::futures::{Future, Stream};
 			use self::bridge::app::{App, Connections};
@@ -151,6 +152,7 @@ macro_rules! test_app_stream {
 				home_bridge: home::HomeBridge::default(),
 				foreign_bridge: foreign::ForeignBridge::default(),
 				timer: Default::default(),
+				running: Arc::new(AtomicBool::new(true)),
 			};
 
 			let app = Arc::new(app);

--- a/tests/tests/deposit_relay.rs
+++ b/tests/tests/deposit_relay.rs
@@ -9,6 +9,8 @@ use bridge::bridge::create_deposit_relay;
 
 const DEPOSIT_TOPIC: &str = "0xe1fffcc4923d04b559f4d29a8bfc6cda04eb5b0d3c460751c2402c5c5cc9109c";
 
+use std::sync::RwLock;
+
 test_app_stream! {
 	name => deposit_relay_basic,
 	database => Database::default(),
@@ -25,7 +27,7 @@ test_app_stream! {
 		],
 		signatures => 1;
 	txs => Transactions::default(),
-	init => |app, db| create_deposit_relay(app, db).take(2),
+	init => |app, db| create_deposit_relay(app, db, Arc::new(RwLock::new(Some(99999999999u64.into())))).take(2),
 	expected => vec![0x1005, 0x1006],
 	home_transport => [
 		"eth_blockNumber" =>
@@ -75,7 +77,7 @@ test_app_stream! {
 		],
 		signatures => 1;
 	txs => Transactions::default(),
-	init => |app, db| create_deposit_relay(app, db).take(2),
+	init => |app, db| create_deposit_relay(app, db, Arc::new(RwLock::new(Some(99999999999u64.into())))).take(2),
 	expected => vec![0x1005, 0x1006],
 	home_transport => [
 		"eth_blockNumber" =>
@@ -147,7 +149,7 @@ test_app_stream! {
 		},
 		..Default::default()
 	},
-	init => |app, db| create_deposit_relay(app, db).take(1),
+	init => |app, db| create_deposit_relay(app, db, Arc::new(RwLock::new(Some(99999999999u64.into())))).take(1),
 	expected => vec![0x1005],
 	home_transport => [
 		"eth_blockNumber" =>
@@ -200,7 +202,7 @@ test_app_stream! {
 		],
 		signatures => 1;
 	txs => Transactions::default(),
-	init => |app, db| create_deposit_relay(app, db).take(1),
+	init => |app, db| create_deposit_relay(app, db, Arc::new(RwLock::new(Some(99999999999u64.into())))).take(1),
 	expected => vec![0x1005],
 	home_transport => [
 		"eth_blockNumber" =>
@@ -255,7 +257,7 @@ test_app_stream! {
 		],
 		signatures => 1;
 	txs => Transactions::default(),
-	init => |app, db| create_deposit_relay(app, db).take(1),
+	init => |app, db| create_deposit_relay(app, db, Arc::new(RwLock::new(Some(99999999999u64.into())))).take(1),
 	expected => vec![0x1005],
 	home_transport => [
 		"eth_blockNumber" =>
@@ -306,7 +308,7 @@ test_app_stream! {
 		],
 		signatures => 1;
 	txs => Transactions::default(),
-	init => |app, db| create_deposit_relay(app, db).take(1),
+	init => |app, db| create_deposit_relay(app, db, Arc::new(RwLock::new(Some(99999999999u64.into())))).take(1),
 	expected => vec![0x1005],
 	home_transport => [
 		"eth_blockNumber" =>

--- a/tests/tests/withdraw_confirm.rs
+++ b/tests/tests/withdraw_confirm.rs
@@ -18,6 +18,8 @@ use ethabi::{encode, Token};
 
 const WITHDRAW_TOPIC: &str = "0xf279e6a1f5e320cca91135676d9cb6e44ca8a08c0b88342bcdb1144f6511b568";
 
+use std::sync::RwLock;
+
 test_app_stream! {
 	name => withdraw_confirm_basic,
 	database => Database::default(),
@@ -34,7 +36,7 @@ test_app_stream! {
 		],
 		signatures => 1;
 	txs => Transactions::default(),
-	init => |app, db| create_withdraw_confirm(app, db).take(2),
+	init => |app, db| create_withdraw_confirm(app, db, Arc::new(RwLock::new(Some(99999999999u64.into())))).take(2),
 	expected => vec![0x1005, 0x1006],
 	home_transport => [],
 	foreign_transport => [
@@ -84,7 +86,7 @@ test_app_stream! {
 		],
 		signatures => 1;
 	txs => Transactions::default(),
-	init => |app, db| create_withdraw_confirm(app, db).take(2),
+	init => |app, db| create_withdraw_confirm(app, db, Arc::new(RwLock::new(Some(99999999999u64.into())))).take(2),
 	expected => vec![0x1005, 0x1006],
 	home_transport => [],
 	foreign_transport => [
@@ -138,7 +140,7 @@ test_app_stream! {
 		],
 		signatures => 1;
 	txs => Transactions::default(),
-	init => |app, db| create_withdraw_confirm(app, db).take(2),
+	init => |app, db| create_withdraw_confirm(app, db, Arc::new(RwLock::new(Some(99999999999u64.into())))).take(2),
 	expected => vec![0x1005, 0x1006],
 	home_transport => [],
 	foreign_transport => [
@@ -199,7 +201,7 @@ test_app_stream! {
 		},
 		..Default::default()
 	},
-	init => |app, db| create_withdraw_confirm(app, db).take(2),
+	init => |app, db| create_withdraw_confirm(app, db, Arc::new(RwLock::new(Some(99999999999u64.into())))).take(2),
 	expected => vec![0x1005, 0x1006],
 	home_transport => [],
 	foreign_transport => [
@@ -304,7 +306,7 @@ test_app_stream! {
 		},
 		..Default::default()
 	},
-	init => |app, db| create_withdraw_confirm(app, db).take(2),
+	init => |app, db| create_withdraw_confirm(app, db, Arc::new(RwLock::new(Some(99999999999u64.into())))).take(2),
 	expected => vec![0x2, 0x1006],
 	home_transport => [],
 	foreign_transport => [

--- a/tests/tests/withdraw_relay.rs
+++ b/tests/tests/withdraw_relay.rs
@@ -18,6 +18,8 @@ use bridge::message_to_mainnet::MessageToMainnet;
 use bridge::signature::Signature;
 use bridge::contracts;
 
+use std::sync::RwLock;
+
 const COLLECTED_SIGNATURES_TOPIC: &str = "0xeb043d149eedb81369bec43d4c3a3a53087debc88d2525f13bfaa3eecda28b5c";
 
 // 1 signature required. relay polled twice.
@@ -39,7 +41,7 @@ test_app_stream! {
 		],
 		signatures => 1;
 	txs => Transactions::default(),
-	init => |app, db| create_withdraw_relay(app, db).take(2),
+	init => |app, db| create_withdraw_relay(app, db, Arc::new(RwLock::new(Some(99999999999u64.into())))).take(2),
 	expected => vec![0x1005, 0x1006],
 	home_transport => [],
 	foreign_transport => [
@@ -90,7 +92,7 @@ test_app_stream! {
 		],
 		signatures => 1;
 	txs => Transactions::default(),
-	init => |app, db| create_withdraw_relay(app, db).take(1),
+	init => |app, db| create_withdraw_relay(app, db, Arc::new(RwLock::new(Some(99999999999u64.into())))).take(1),
 	expected => vec![0x1005],
 	home_transport => [],
 	foreign_transport => [
@@ -138,7 +140,7 @@ test_app_stream! {
 		],
 		signatures => 2;
 	txs => Transactions::default(),
-	init => |app, db| create_withdraw_relay(app, db).take(1),
+	init => |app, db| create_withdraw_relay(app, db, Arc::new(RwLock::new(Some(99999999999u64.into())))).take(1),
 	expected => vec![0x1005],
 	home_transport => [
 		// `HomeBridge.withdraw`


### PR DESCRIPTION
Solution: use an updated version of the API
to make them compile