### PR TITLE
Problem: withdraw_confirm failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,7 @@ dependencies = [
  "ethereum-types 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "keccak-hash 0.1.0 (git+http://github.com/paritytech/parity?rev=991f0ca)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -22,6 +22,7 @@ ethereum-types = "0.3"
 pretty_assertions = "0.2.1"
 ethcore = { git = "http://github.com/paritytech/parity", rev = "991f0ca" }
 rlp = { git = "http://github.com/paritytech/parity", rev = "991f0ca" }
+keccak-hash = { git = "http://github.com/paritytech/parity", rev = "991f0ca" }
 ethcore-transaction = { git = "http://github.com/paritytech/parity", rev = "991f0ca" }
 itertools = "0.7"
 

--- a/bridge/src/lib.rs
+++ b/bridge/src/lib.rs
@@ -25,6 +25,7 @@ extern crate pretty_assertions;
 extern crate ethcore;
 extern crate ethcore_transaction;
 extern crate rlp;
+extern crate keccak_hash;
 
 extern crate itertools;
 


### PR DESCRIPTION
If a node configured as Foreign for the bridge and it has no validator
account unlocked the bridge crashes and produces the following message:

```
INFO:bridge::bridge::withdraw_confirm: got 1 new withdraws to sign
INFO:bridge::bridge::withdraw_confirm: withdraw is ready for signature
submission. tx hash 0x6493…4fa8
INFO:bridge::bridge::withdraw_confirm: signing
WARN:bridge: Bridge crashed with Error(Transport("Unexpected response
status code: 405 Method Not Allowed"), State { next_error: None,
backtrace: None })
Error(Transport("Unexpected response status code: 405 Method Not
Allowed"), State { next_error: None, backtrace: None })
```

Solution: sign messages locally

Closes #49