### PR TITLE
Problem: nonce reuse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,7 @@ dependencies = [
  "ethereum-types 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "keccak-hash 0.1.0 (git+http://github.com/paritytech/parity?rev=991f0ca)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -25,6 +25,7 @@ rlp = { git = "http://github.com/paritytech/parity", rev = "991f0ca" }
 keccak-hash = { git = "http://github.com/paritytech/parity", rev = "991f0ca" }
 ethcore-transaction = { git = "http://github.com/paritytech/parity", rev = "991f0ca" }
 itertools = "0.7"
+jsonrpc-core = "8.0"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/bridge/src/api.rs
+++ b/bridge/src/api.rs
@@ -18,12 +18,6 @@ pub struct ApiCall<T, F> {
 	message: &'static str,
 }
 
-impl<T, F> ApiCall<T, F> {
-	pub fn message(&self) -> &'static str {
-		self.message
-	}
-}
-
 impl<T: DeserializeOwned, F: Future<Item = Value, Error = web3::Error>>Future for ApiCall<T, F> {
 	type Item = T;
 	type Error = Error;
@@ -92,6 +86,8 @@ pub fn send_raw_transaction<T: Transport>(transport: T, tx: Bytes) -> ApiCall<H2
 		message: "eth_sendRawTransaction",
 	}
 }
+
+pub use bridge::nonce::send_transaction_with_nonce;
 
 /// Imperative wrapper for web3 function.
 pub fn call<T: Transport>(transport: T, address: Address, payload: Bytes) -> ApiCall<Bytes, T::Out> {

--- a/bridge/src/bridge/mod.rs
+++ b/bridge/src/bridge/mod.rs
@@ -1,7 +1,7 @@
 mod deploy;
 mod balance;
 mod chain_id;
-mod nonce;
+pub mod nonce;
 mod deposit_relay;
 mod withdraw_confirm;
 mod withdraw_relay;
@@ -18,7 +18,6 @@ use error::{Error, ErrorKind, Result};
 
 pub use self::deploy::{Deploy, Deployed, create_deploy};
 pub use self::balance::{BalanceCheck, create_balance_check};
-pub use self::nonce::{NonceCheck, create_nonce_check};
 pub use self::chain_id::{ChainIdRetrieval, create_chain_id_retrieval};
 pub use self::deposit_relay::{DepositRelay, create_deposit_relay};
 pub use self::withdraw_relay::{WithdrawRelay, create_withdraw_relay};
@@ -85,20 +84,14 @@ pub fn create_bridge<T: Transport + Clone>(app: Arc<App<T>>, init: &Database, ho
 pub fn create_bridge_backed_by<T: Transport + Clone, F: BridgeBackend>(app: Arc<App<T>>, init: &Database, backend: F, home_chain_id: u64, foreign_chain_id: u64) -> Bridge<T, F> {
 	let home_balance = Arc::new(RwLock::new(None));
 	let foreign_balance = Arc::new(RwLock::new(None));
-	let home_nonce = Arc::new(RwLock::new(None));
-	let foreign_nonce = Arc::new(RwLock::new(None));
 	Bridge {
 		foreign_balance_check: create_balance_check(app.connections.foreign.clone(), app.config.foreign.clone()),
 		home_balance_check: create_balance_check(app.connections.home.clone(), app.config.home.clone()),
 		foreign_balance: foreign_balance.clone(),
 		home_balance: home_balance.clone(),
-		home_nonce: home_nonce.clone(),
-		foreign_nonce: foreign_nonce.clone(),
-		home_nonce_check: create_nonce_check(app.connections.home.clone(), app.config.home.clone()),
-		foreign_nonce_check: create_nonce_check(app.connections.foreign.clone(), app.config.foreign.clone()),
-		deposit_relay: create_deposit_relay(app.clone(), init, foreign_balance.clone(), foreign_chain_id, foreign_nonce.clone()),
-		withdraw_relay: create_withdraw_relay(app.clone(), init, home_balance.clone(), home_chain_id, home_nonce.clone()),
-		withdraw_confirm: create_withdraw_confirm(app.clone(), init, foreign_balance.clone(), foreign_chain_id, foreign_nonce.clone()),
+		deposit_relay: create_deposit_relay(app.clone(), init, foreign_balance.clone(), foreign_chain_id),
+		withdraw_relay: create_withdraw_relay(app.clone(), init, home_balance.clone(), home_chain_id),
+		withdraw_confirm: create_withdraw_confirm(app.clone(), init, foreign_balance.clone(), foreign_chain_id),
 		state: BridgeStatus::Wait,
 		backend,
 		running: app.running.clone(),
@@ -110,10 +103,6 @@ pub struct Bridge<T: Transport, F> {
 	foreign_balance_check: BalanceCheck<T>,
 	home_balance: Arc<RwLock<Option<U256>>>,
 	foreign_balance: Arc<RwLock<Option<U256>>>,
-	home_nonce: Arc<RwLock<Option<U256>>>,
-	foreign_nonce: Arc<RwLock<Option<U256>>>,
-	home_nonce_check: NonceCheck<T>,
-	foreign_nonce_check: NonceCheck<T>,
 	deposit_relay: DepositRelay<T>,
 	withdraw_relay: WithdrawRelay<T>,
 	withdraw_confirm: WithdrawConfirm<T>,
@@ -145,17 +134,6 @@ impl<T: Transport, F: BridgeBackend> Bridge<T, F> {
 		}
 	}
 
-	fn check_nonces(&mut self) -> Poll<Option<()>, Error> {
-		let mut home_nonce = self.home_nonce.write().unwrap();
-		let mut foreign_nonce = self.foreign_nonce.write().unwrap();
-		*home_nonce = try_bridge!(self.home_nonce_check.poll()).or(*home_nonce);
-		*foreign_nonce = try_bridge!(self.foreign_nonce_check.poll()).or(*foreign_nonce);
-		if home_nonce.is_none() || foreign_nonce.is_none() {
-			Ok(Async::NotReady)
-		} else {
-			Ok(Async::Ready(None))
-		}
-	}
 }
 
 impl<T: Transport, F: BridgeBackend> Stream for Bridge<T, F> {
@@ -181,35 +159,22 @@ impl<T: Transport, F: BridgeBackend> Stream for Bridge<T, F> {
 						return Ok(Async::NotReady)
 					}
 
-					let nonce_is_absent = {
-						let mut home_nonce = self.home_nonce.read().unwrap();
-						let mut foreign_nonce = self.foreign_nonce.read().unwrap();
-						home_nonce.is_none() || foreign_nonce.is_none()
-					};
-					if nonce_is_absent {
-						self.check_nonces()?;
-						return Ok(Async::NotReady)
-					}
-
 					let d_relay = try_bridge!(self.deposit_relay.poll()).map(BridgeChecked::DepositRelay);
 
 					if d_relay.is_some() {
 						self.check_balances()?;
-						self.check_nonces()?;
 					}
 
 					let w_relay = try_bridge!(self.withdraw_relay.poll()).map(BridgeChecked::WithdrawRelay);
 
 					if w_relay.is_some() {
 						self.check_balances()?;
-						self.check_nonces()?;
 					}
 
 					let w_confirm = try_bridge!(self.withdraw_confirm.poll()).map(BridgeChecked::WithdrawConfirm);
 
 					if w_confirm.is_some() {
 						self.check_balances()?;
-						self.check_nonces()?;
 					}
 
 					let result: Vec<_> = [d_relay, w_relay, w_confirm]

--- a/bridge/src/bridge/nonce.rs
+++ b/bridge/src/bridge/nonce.rs
@@ -13,12 +13,16 @@ use rpc;
 
 /// State of balance checking.
 enum NonceCheckState<T: Transport, S: TransactionSender> {
-	// Ready to perform the transaction
+	/// Ready
 	Ready,
+	/// Ready to request nonce
+	Reacquire,
 	/// Nonce request is in progress.
 	NonceRequest {
 		future: Timeout<ApiCall<U256, T::Out>>,
 	},
+	/// Nonce available
+	Nonce(U256),
 	/// Transaction is in progress
 	TransactionRequest {
 		future: Timeout<S::Future>,
@@ -66,14 +70,28 @@ impl<T: Transport, S: TransactionSender> Future for NonceCheck<T, S> {
 		loop {
 			let next_state = match self.state {
 				NonceCheckState::Ready => {
+					let result = NonceCheckState::Nonce(self.node.info.nonce.read().unwrap().clone());
+					{
+						let mut node_nonce = self.node.info.nonce.write().unwrap();
+						let (next, _) = node_nonce.overflowing_add(U256::one());
+						*node_nonce = next;
+					}
+					result
+				},
+				NonceCheckState::Reacquire => {
 					NonceCheckState::NonceRequest {
 						future: self.timer.timeout(api::eth_get_transaction_count(&self.transport, self.node.account, None),
 						                           self.node.request_timeout),
 					}
 				},
 				NonceCheckState::NonceRequest { ref mut future } => {
-					let value = try_ready!(future.poll());
-					self.transaction.nonce = value;
+					let nonce = try_ready!(future.poll());
+					let mut node_nonce = self.node.info.nonce.write().unwrap();
+					*node_nonce = nonce;
+					NonceCheckState::Nonce(nonce)
+				},
+				NonceCheckState::Nonce(mut nonce) => {
+					self.transaction.nonce = nonce;
 					match prepare_raw_transaction(self.transaction.clone(), &self.app, &self.node, self.chain_id) {
 						Ok(tx) => NonceCheckState::TransactionRequest {
 							future: self.timer.timeout(self.sender.send(tx), self.node.request_timeout)
@@ -89,7 +107,11 @@ impl<T: Transport, S: TransactionSender> Future for NonceCheck<T, S> {
 							Error(ErrorKind::Web3(web3::error::Error(web3::error::ErrorKind::Rpc(rpc_err), _)), _) => {
 								if rpc_err.code == rpc::ErrorCode::ServerError(-32010) && rpc_err.message.ends_with("incrementing the nonce.") {
 									// restart the process
-									NonceCheckState::Ready
+									NonceCheckState::Reacquire
+								} else if rpc_err.code == rpc::ErrorCode::ServerError(-32010) && rpc_err.message.ends_with("already imported.") {
+									let hash = self.transaction.hash(Some(self.chain_id));
+									info!("{} already imported on {}, skipping", hash, self.node.rpc_host);
+									return Ok(Async::Ready(self.sender.ignore(hash)))
 								} else {
 									return Err(ErrorKind::Web3(web3::error::ErrorKind::Rpc(rpc_err).into()).into());
 								}
@@ -108,6 +130,7 @@ pub trait TransactionSender {
 	type T;
 	type Future : Future<Item = Self::T, Error = Error>;
 	fn send(&self, tx: Bytes) -> Self::Future;
+	fn ignore(&self, hash: H256) -> Self::T;
 }
 
 pub struct SendRawTransaction<T: Transport>(pub T);
@@ -119,6 +142,11 @@ impl<T: Transport + Clone> TransactionSender for SendRawTransaction<T> {
 	fn send(&self, tx: Bytes) -> <Self as TransactionSender>::Future {
 		api::send_raw_transaction(self.0.clone(), tx)
 	}
+
+	fn ignore(&self, hash: H256) -> Self::T {
+		hash
+	}
+
 }
 
 use std::time::Duration;
@@ -134,6 +162,13 @@ impl<T: Transport + Clone> TransactionSender for TransactionWithConfirmation<T> 
 		api::send_raw_transaction_with_confirmation(self.0.clone(), tx, self.1, self.2)
 			.map_err( web3_error_to_error)
 	}
+
+	fn ignore(&self, hash: H256) -> Self::T {
+		let mut receipt = TransactionReceipt::default();
+		receipt.transaction_hash = hash;
+		receipt
+	}
+
 }
 
 fn web3_error_to_error(err: web3::Error) -> Error {

--- a/bridge/src/bridge/nonce.rs
+++ b/bridge/src/bridge/nonce.rs
@@ -1,56 +1,71 @@
-use futures::{Future, Stream, Poll};
+use futures::{Future, Async, Poll, future::{MapErr}};
 use tokio_timer::{Timer, Timeout};
-use web3::Transport;
-use web3::types::U256;
+use web3::{self, Transport};
+use web3::types::{U256, H256, Bytes};
+use ethcore_transaction::Transaction;
 use api::{self, ApiCall};
-use error::Error;
+use error::{Error, ErrorKind};
 use config::Node;
+use transaction::prepare_raw_transaction;
+use app::App;
+use std::sync::Arc;
+use rpc;
 
 /// State of balance checking.
-enum NonceCheckState<T: Transport> {
-	/// Deposit relay is waiting for logs.
-	Wait,
-	/// Balance request is in progress.
+enum NonceCheckState<T: Transport, S: TransactionSender> {
+	// Ready to perform the transaction
+	Ready,
+	/// Nonce request is in progress.
 	NonceRequest {
 		future: Timeout<ApiCall<U256, T::Out>>,
 	},
-	/// Balance request completed.
-	Yield(Option<U256>),
+	/// Transaction is in progress
+	TransactionRequest {
+		future: Timeout<S::Future>,
+	},
 }
 
-pub struct NonceCheck<T: Transport> {
+pub struct NonceCheck<T: Transport, S: TransactionSender> {
+	app: Arc<App<T>>,
 	transport: T,
-	state: NonceCheckState<T>,
+	state: NonceCheckState<T, S>,
 	timer: Timer,
 	node: Node,
+	transaction: Transaction,
+	chain_id: u64,
+	sender: S,
 }
 
 use std::fmt::{self, Debug};
 
-impl<T: Transport> Debug for NonceCheck<T> {
+impl<T: Transport, S: TransactionSender> Debug for NonceCheck<T, S> {
 	fn fmt(&self, _fmt: &mut fmt::Formatter) -> fmt::Result {
 		Ok(())
 	}
 
 }
 
-pub fn create_nonce_check<T: Transport + Clone>(transport: T, node: Node) -> NonceCheck<T> {
+pub fn send_transaction_with_nonce<T: Transport + Clone, S: TransactionSender>(transport: T, app: Arc<App<T>>, node: Node, transaction: Transaction, chain_id: u64, sender: S) -> NonceCheck<T, S> {
 	NonceCheck {
-		state: NonceCheckState::Wait,
+		app,
+		state: NonceCheckState::Ready,
 		timer: Timer::default(),
 		transport,
 		node,
+		transaction,
+		chain_id,
+		sender,
 	}
 }
 
-impl<T: Transport> Stream for NonceCheck<T> {
-	type Item = U256;
+impl<T: Transport, S: TransactionSender> Future for NonceCheck<T, S> {
+	type Item = S::T;
 	type Error = Error;
 
-	fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+	fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
 		loop {
 			let next_state = match self.state {
-				NonceCheckState::Wait => {
+				NonceCheckState::Ready => {
 					NonceCheckState::NonceRequest {
 						future: self.timer.timeout(api::eth_get_transaction_count(&self.transport, self.node.account, None),
 						                           self.node.request_timeout),
@@ -58,14 +73,69 @@ impl<T: Transport> Stream for NonceCheck<T> {
 				},
 				NonceCheckState::NonceRequest { ref mut future } => {
 					let value = try_ready!(future.poll());
-					NonceCheckState::Yield(Some(value))
+					self.transaction.nonce = value;
+					match prepare_raw_transaction(self.transaction.clone(), &self.app, &self.node, self.chain_id) {
+						Ok(tx) => NonceCheckState::TransactionRequest {
+							future: self.timer.timeout(self.sender.send(tx), self.node.request_timeout)
+						},
+						Err(e) => return Err(e),
+					}
 				},
-				NonceCheckState::Yield(ref mut nonce) => match  nonce.take() {
-					None => NonceCheckState::Wait,
-					some => return Ok(some.into()),
-				}
+				NonceCheckState::TransactionRequest { ref mut future } => {
+					match future.poll() {
+						Ok(Async::Ready(t)) => return Ok(Async::Ready(t)),
+						Ok(Async::NotReady) => return Ok(Async::NotReady),
+						Err(e) => match e {
+							Error(ErrorKind::Web3(web3::error::Error(web3::error::ErrorKind::Rpc(rpc_err), _)), _) => {
+								if rpc_err.code == rpc::ErrorCode::ServerError(-32010) && rpc_err.message.ends_with("incrementing the nonce.") {
+									// restart the process
+									NonceCheckState::Ready
+								} else {
+									return Err(ErrorKind::Web3(web3::error::ErrorKind::Rpc(rpc_err).into()).into());
+								}
+							},
+							e => return Err(From::from(e)),
+						},
+					}
+				},
 			};
 			self.state = next_state;
 		}
 	}
+}
+
+pub trait TransactionSender {
+	type T;
+	type Future : Future<Item = Self::T, Error = Error>;
+	fn send(&self, tx: Bytes) -> Self::Future;
+}
+
+pub struct SendRawTransaction<T: Transport>(pub T);
+
+impl<T: Transport + Clone> TransactionSender for SendRawTransaction<T> {
+	type T = H256;
+	type Future = ApiCall<Self::T, T::Out>;
+
+	fn send(&self, tx: Bytes) -> <Self as TransactionSender>::Future {
+		api::send_raw_transaction(self.0.clone(), tx)
+	}
+}
+
+use std::time::Duration;
+pub struct TransactionWithConfirmation<T: Transport>(pub T, pub Duration, pub usize);
+
+use web3::types::TransactionReceipt;
+
+impl<T: Transport + Clone> TransactionSender for TransactionWithConfirmation<T> {
+	type T = TransactionReceipt;
+	type Future = MapErr<web3::confirm::SendTransactionWithConfirmation<T>, fn(::web3::Error) -> Error>;
+
+	fn send(&self, tx: Bytes) -> <Self as TransactionSender>::Future {
+		api::send_raw_transaction_with_confirmation(self.0.clone(), tx, self.1, self.2)
+			.map_err( web3_error_to_error)
+	}
+}
+
+fn web3_error_to_error(err: web3::Error) -> Error {
+	ErrorKind::Web3(err).into()
 }

--- a/bridge/src/bridge/withdraw_confirm.rs
+++ b/bridge/src/bridge/withdraw_confirm.rs
@@ -1,20 +1,18 @@
 use std::sync::{Arc, RwLock};
 use std::ops;
-use futures::{self, Future, Stream, Poll};
-use futures::future::{JoinAll, join_all};
-use tokio_timer::Timeout;
+use futures::{self, Future, Stream, stream::{Collect, IterOk, iter_ok, Buffered}, Poll};
 use web3::Transport;
-use web3::types::{H256, U256, H520, Address, Bytes, FilterBuilder};
-use api::{self, LogStream, ApiCall};
+use web3::types::{U256, H520, Address, Bytes, FilterBuilder};
+use api::{self, LogStream};
 use app::App;
 use contracts::foreign;
 use util::web3_filter;
 use database::Database;
 use error::{Error, ErrorKind};
 use message_to_mainnet::{MessageToMainnet, MESSAGE_LENGTH};
-use transaction::prepare_raw_transaction;
 use ethcore_transaction::{Transaction, Action};
 use itertools::Itertools;
+use super::nonce::{NonceCheck, SendRawTransaction};
 
 fn withdraws_filter(foreign: &foreign::ForeignBridge, address: Address) -> FilterBuilder {
 	let filter = foreign.events().withdraw().create_filter();
@@ -32,14 +30,14 @@ enum WithdrawConfirmState<T: Transport> {
 	Wait,
 	/// Confirming withdraws.
 	ConfirmWithdraws {
-		future: JoinAll<Vec<Timeout<ApiCall<H256, T::Out>>>>,
+		future: Collect<Buffered<IterOk<::std::vec::IntoIter<NonceCheck<T, SendRawTransaction<T>>>, Error>>>,
 		block: u64,
 	},
 	/// All withdraws till given block has been confirmed.
 	Yield(Option<u64>),
 }
 
-pub fn create_withdraw_confirm<T: Transport + Clone>(app: Arc<App<T>>, init: &Database, foreign_balance: Arc<RwLock<Option<U256>>>, foreign_chain_id: u64, foreign_nonce: Arc<RwLock<Option<U256>>>) -> WithdrawConfirm<T> {
+pub fn create_withdraw_confirm<T: Transport + Clone>(app: Arc<App<T>>, init: &Database, foreign_balance: Arc<RwLock<Option<U256>>>, foreign_chain_id: u64) -> WithdrawConfirm<T> {
 	let logs_init = api::LogStreamInit {
 		after: init.checked_withdraw_confirm,
 		request_timeout: app.config.foreign.request_timeout,
@@ -54,7 +52,6 @@ pub fn create_withdraw_confirm<T: Transport + Clone>(app: Arc<App<T>>, init: &Da
 		state: WithdrawConfirmState::Wait,
 		app,
 		foreign_balance,
-		foreign_nonce,
 		foreign_chain_id,
 	}
 }
@@ -65,7 +62,6 @@ pub struct WithdrawConfirm<T: Transport> {
 	state: WithdrawConfirmState<T>,
 	foreign_contract: Address,
 	foreign_balance: Arc<RwLock<Option<U256>>>,
-	foreign_nonce: Arc<RwLock<Option<U256>>>,
 	foreign_chain_id: u64,
 }
 
@@ -79,8 +75,6 @@ impl<T: Transport> Stream for WithdrawConfirm<T> {
 		let gas = self.app.config.txs.withdraw_confirm.gas.into();
 		let gas_price = self.app.config.txs.withdraw_confirm.gas_price.into();
 		let contract = self.foreign_contract.clone();
-		let foreign = &self.app.config.foreign;
-		let chain_id = self.foreign_chain_id;
 		loop {
 			let next_state = match self.state {
 				WithdrawConfirmState::Wait => {
@@ -89,14 +83,10 @@ impl<T: Transport> Stream for WithdrawConfirm<T> {
 						warn!("foreign contract balance is unknown");
 						return Ok(futures::Async::NotReady);
 					}
-					let foreign_nonce = self.foreign_nonce.read().unwrap();
-					if foreign_nonce.is_none() {
-						warn!("foreign nonce is unknown");
-						return Ok(futures::Async::NotReady);
-					}
 
 					let item = try_stream!(self.logs.poll());
-					info!("got {} new withdraws to sign", item.logs.len());
+					let len = item.logs.len();
+					info!("got {} new withdraws to sign", len);
 					let mut messages = item.logs
 						.into_iter()
 						.map(|log| {
@@ -137,25 +127,16 @@ impl<T: Transport> Stream for WithdrawConfirm<T> {
 								gas, gas_price,
 								value: U256::zero(),
 								data: payload.0,
-								nonce: foreign_nonce.unwrap(),
+								nonce: U256::zero(),
 								action: Action::Call(contract),
 							};
-							prepare_raw_transaction(tx, app, foreign, chain_id)
-						})
-						.map_results(|tx| {
-							info!("submitting signature");
-							app.timer.timeout(
-								api::send_raw_transaction(&app.connections.foreign, tx),
-								app.config.foreign.request_timeout)
-						})
-						.fold_results(vec![], |mut acc, tx| {
-							acc.push(tx);
-							acc
-						})?;
+							api::send_transaction_with_nonce(self.app.connections.foreign.clone(), self.app.clone(), self.app.config.foreign.clone(),
+															 tx, self.foreign_chain_id, SendRawTransaction(self.app.connections.foreign.clone()))
+						}).collect_vec();
 
-					info!("submitting {} signatures", confirmations.len());
+					info!("submitting {} signatures", len);
 					WithdrawConfirmState::ConfirmWithdraws {
-						future: join_all(confirmations),
+						future: iter_ok(confirmations).buffered(1).collect(),
 						block,
 					}
 				},

--- a/bridge/src/config.rs
+++ b/bridge/src/config.rs
@@ -63,6 +63,29 @@ pub struct Node {
 	pub rpc_host: String,
 	pub rpc_port: u16,
 	pub password: PathBuf,
+	pub info: NodeInfo,
+}
+
+use std::sync::{Arc, RwLock};
+use web3::types::U256;
+
+#[derive(Debug, Clone)]
+pub struct NodeInfo {
+    pub nonce: Arc<RwLock<U256>>,
+}
+
+impl Default for NodeInfo {
+	fn default() -> Self {
+		NodeInfo {
+			nonce: Arc::new(RwLock::new(U256::zero())),
+		}
+	}
+}
+
+impl PartialEq for NodeInfo {
+	fn eq(&self, rhs: &Self) -> bool {
+		*self.nonce.read().unwrap() == *rhs.nonce.read().unwrap()
+	}
 }
 
 impl Node {
@@ -83,6 +106,7 @@ impl Node {
 			rpc_host: node.rpc_host.unwrap(),
 			rpc_port: node.rpc_port.unwrap_or(DEFAULT_RPC_PORT),
 			password: node.password,
+			info: Default::default(),
 		};
 
 		Ok(result)

--- a/bridge/src/error.rs
+++ b/bridge/src/error.rs
@@ -1,7 +1,6 @@
 #![allow(unknown_lints)]
 
 use std::io;
-use api::ApiCall;
 use tokio_timer::{TimerError, TimeoutError};
 use {web3, toml, ethabi, rustc_hex};
 use ethcore::ethstore;
@@ -54,12 +53,13 @@ error_chain! {
 	}
 }
 
-impl<T, F> From<TimeoutError<ApiCall<T, F>>> for Error {
-	fn from(err: TimeoutError<ApiCall<T, F>>) -> Self {
+impl<T> From<TimeoutError<T>> for Error {
+	fn from(err: TimeoutError<T>) -> Self {
 		match err {
-			TimeoutError::Timer(call, _) | TimeoutError::TimedOut(call) => {
-				ErrorKind::Timeout(call.message()).into()
+			TimeoutError::Timer(_call, _) | TimeoutError::TimedOut(_call) => {
+				ErrorKind::Timeout("communication timeout").into()
 			}
 		}
 	}
 }
+

--- a/bridge/src/lib.rs
+++ b/bridge/src/lib.rs
@@ -26,6 +26,7 @@ extern crate ethcore;
 extern crate ethcore_transaction;
 extern crate rlp;
 extern crate keccak_hash;
+extern crate jsonrpc_core as rpc;
 
 extern crate itertools;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -19,7 +19,7 @@ use futures::{Stream, future};
 use tokio_core::reactor::Core;
 
 use bridge::app::App;
-use bridge::bridge::{create_bridge, create_deploy, create_chain_id_retrieval, create_nonce_check, Deployed};
+use bridge::bridge::{create_bridge, create_deploy, create_chain_id_retrieval, Deployed};
 use bridge::config::Config;
 use bridge::error::{Error, ErrorKind};
 use bridge::web3;
@@ -141,15 +141,8 @@ fn execute<S, I>(command: I, running: Arc<AtomicBool>) -> Result<String, UserFac
 
 	info!(target: "bridge", "Home chain ID: {} Foreign chain ID: {}", home_chain_id, foreign_chain_id);
 
-	let (home_nonce, _) = event_loop.run(create_nonce_check(app.connections.home.clone(), app.config.home.clone()).into_future()).expect("can't retrieve home nonce");
-	let home_nonce = home_nonce.expect("can't retrieve home nonce");
-
-	let (foreign_nonce, _) = event_loop.run(create_nonce_check(app.connections.foreign.clone(), app.config.foreign.clone()).into_future()).expect("can't retrieve foreign nonce");
-	let foreign_nonce = foreign_nonce.expect("can't retrieve foreign nonce");
-
-
 	info!(target: "bridge", "Deploying contracts (if needed)");
-	let deployed = event_loop.run(create_deploy(app.clone(), home_chain_id, foreign_chain_id, home_nonce, foreign_nonce))?;
+	let deployed = event_loop.run(create_deploy(app.clone(), home_chain_id, foreign_chain_id))?;
 
 	let database = match deployed {
 		Deployed::New(database) => {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -141,6 +141,15 @@ fn execute<S, I>(command: I, running: Arc<AtomicBool>) -> Result<String, UserFac
 
 	info!(target: "bridge", "Home chain ID: {} Foreign chain ID: {}", home_chain_id, foreign_chain_id);
 
+	{
+		use bridge::api;
+		let mut home_nonce = app.config.home.info.nonce.write().unwrap();
+		let mut foreign_nonce = app.config.foreign.info.nonce.write().unwrap();
+
+		*home_nonce = event_loop.run(api::eth_get_transaction_count(app.connections.home.clone(), app.config.home.account, None)).expect("can't initialize home nonce");
+		*foreign_nonce = event_loop.run(api::eth_get_transaction_count(app.connections.foreign.clone(), app.config.foreign.account, None)).expect("can't initialize foreign nonce");
+	}
+
 	info!(target: "bridge", "Deploying contracts (if needed)");
 	let deployed = event_loop.run(create_deploy(app.clone(), home_chain_id, foreign_chain_id))?;
 


### PR DESCRIPTION
Unfortunately, bridge will still reuse nonce very often.
Specifically when trying to send more than one transaction at
a time, clearly a faulty behaviour.

Solution: chain retrieving a nonce with subsequent sending
of the transaction.

However, chaining these is not enough as it'll still fail.

This is happening because bridge module is polling all its components
(deposit_relay, withdraw_confirm, withdraw_relay) sequentially,
 and some of them maybe waiting on their transactions to go through.

However, those transactions are also done as composed futures of nonce
retrieval and transaction sending. This means that it is very often
that first, these futures will go through the nonce acquisition process,
get the same values, and then submit transactions with the same nonce.

This patch makes NonceCheck future check if the transaction failed
with this specific issue of nonce reuse and effectively restarts from
the beginning in that case, repeating nonce acquisition process... until
it succeeeds.